### PR TITLE
Add \value macros to the docs (CRAN request)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^Makefile$
 ^codecov\.yml$
 ^cran-comments\.md$
+^CRAN-RELEASE$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,6 @@ Description: Scrapes and cleans data on targeted public investments from Platafo
     the responsible system to request, execute, and monitor federal discretionary transfers in Brazil.
 License: GPL (>= 3)
 Encoding: UTF-8
-LazyData: true
 URL: https://github.com/meirelesff/siconvr, https://fmeireles.com/siconvr/
 BugReports: https://github.com/meirelesff/siconvr/issues
 Roxygen: list(markdown = TRUE)

--- a/R/get_siconv.R
+++ b/R/get_siconv.R
@@ -43,6 +43,16 @@
 #' @param verbose Should the function display messages and progress bar? Defaults
 #' to `TRUE`.
 #'
+#' @note `get_siconv()` needs an internet connection to download data in case it
+#' does not found a cache folder with raw data from a previous request. Be aware that instability
+#' in the Plataforma +Brasil server might produce error messagens, in which case users
+#' should try waiting before rerunning their requests.
+#'
+#'
+#' @return A \link[tibble]{tibble} contantaining the requested data as defined in the
+#' `dataset` argument. Use the \code{\link{show_schema}} function to get detailed information
+#' on available variables and information.
+#'
 #' @export
 #' @examples
 #' \dontrun{df <- get_siconv(dataset = "propostas")}

--- a/R/show_schema.R
+++ b/R/show_schema.R
@@ -10,6 +10,15 @@
 #' @param browser Should the function open a web browser to display the docs?
 #' Defaults to `TRUE`.
 #'
+#' @return `show_schema()` is most usefull for its side effect of downloading,
+#' when needed, and opening Plataforma +Brasil's documentation, but is also silently
+#' returns a string containing the path to the docs' index file.
+#'
+#' @note `show_schema()` needs an internet connection to download data in case it
+#' does not found a cache folder with the docs from a previous request. Be aware that instability
+#' in the Plataforma +Brasil server might produce error messagens, in which case users
+#' should try waiting before rerunning the function.
+#'
 #' @export
 #' @examples
 #' \dontrun{show_schema()}
@@ -36,7 +45,7 @@ show_schema <- function(verbose = TRUE, browser = TRUE){
   # Display them in the users' browser
   if(browser) {
 
-    if(!file.exists(docs)) stop("Failed to download Plataforma +Brasil docs.")
+    if(!file.exists(docs)) stop("Failed to download Plataforma +Brasil's docs.")
     utils::browseURL(docs)
   }
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,9 @@
+## Resubmission
+
+Thanks for the review. This time we improved the documentation by adding \value 
+to main functions, as well as two \note alerting users they need internet connection 
+to download data.
+
 ## Test environments
 
 * Ubuntu 20.04 (personal computer), R 4.0.5
@@ -9,7 +15,10 @@
 
 ## R CMD check results
 
-0 errors | 0 warnings | 0 note*
+0 errors | 0 warnings | 1 note
+
+* There's a note suggesting the title case form of the title field to be set as "Plataforma +brasil". 
+We use instead "Plataforma +Brasil" since that is the data provider's name.
 
 * There's a note on winbuilder regarding a possibly misspelled word, "Plataforma +Brasil",
 which is the data provider's name.

--- a/man/get_siconv.Rd
+++ b/man/get_siconv.Rd
@@ -45,12 +45,23 @@ changing files' names inside this folder).}
 \item{verbose}{Should the function display messages and progress bar? Defaults
 to \code{TRUE}.}
 }
+\value{
+A \link[tibble]{tibble} contantaining the requested data as defined in the
+\code{dataset} argument. Use the \code{\link{show_schema}} function to get detailed information
+on available variables and information.
+}
 \description{
 \code{get_siconv()} is the package's workhorse. It downloads, cleans, and
 returns one of the several datasets maintained by Plataforma +Brasil on federal
 targeted transfers in Brazil. Under the hoods, the function handles GET requests,
 downloads and stores intermediary files, and reads as fast as possible the data
 to a \code{tibble} format convenient for use in analysis.
+}
+\note{
+\code{get_siconv()} needs an internet connection to download data in case it
+does not found a cache folder with raw data from a previous request. Be aware that instability
+in the Plataforma +Brasil server might produce error messagens, in which case users
+should try waiting before rerunning their requests.
 }
 \examples{
 \dontrun{df <- get_siconv(dataset = "propostas")}

--- a/man/show_schema.Rd
+++ b/man/show_schema.Rd
@@ -13,10 +13,21 @@ to \code{TRUE}.}
 \item{browser}{Should the function open a web browser to display the docs?
 Defaults to \code{TRUE}.}
 }
+\value{
+\code{show_schema()} is most usefull for its side effect of downloading,
+when needed, and opening Plataforma +Brasil's documentation, but is also silently
+returns a string containing the path to the docs' index file.
+}
 \description{
 \code{show_schema()} downloads, unzips, and show in a web browser Plataforma +Brasil's
 full database documentation, including its schema and other usefull information.
 Docs are downloaded to a folder in the working directory.
+}
+\note{
+\code{show_schema()} needs an internet connection to download data in case it
+does not found a cache folder with the docs from a previous request. Be aware that instability
+in the Plataforma +Brasil server might produce error messagens, in which case users
+should try waiting before rerunning the function.
 }
 \examples{
 \dontrun{show_schema()}


### PR DESCRIPTION
This responds to a CRAN reviewer request. Used the chance to add two notes in the docs alerting users a internet connection is needed to download data for the first time (following runs might take advantage of the cache).